### PR TITLE
#25: 変更ない場合publishしない

### DIFF
--- a/src/model/database.go
+++ b/src/model/database.go
@@ -8,6 +8,7 @@ import (
 )
 
 type Database struct {
+	dirty                bool
 	maxPasswordId        int
 	PasswordMap          map[int]*Password
 	CategoryMap          map[string]*Category
@@ -19,8 +20,17 @@ func (d *Database) GetNextPasswordId() int {
 	return d.maxPasswordId
 }
 
+func (d *Database) SetDirty(dirty bool) {
+	d.dirty = dirty
+}
+
+func (d *Database) IsDirty() bool {
+	return d.dirty
+}
+
 func NewDatabase() *Database {
 	return &Database{
+		dirty:                false,
 		PasswordMap:          map[int]*Password{},
 		CategoryMap:          map[string]*Category{},
 		CategorizedPasswords: map[string][]*Password{},

--- a/src/repo/repo.go
+++ b/src/repo/repo.go
@@ -17,19 +17,24 @@ func NewRepository(database *model.Database) *Repository {
 	return r
 }
 
-func (repo *Repository) GetSortedCategories() []*model.Category {
-	ret := []*model.Category{}
-	for _, cat := range repo.database.CategoryMap {
-		ret = append(ret, cat)
-	}
-	sort.SliceStable(ret, func(i, j int) bool {
-		a := ret[i]
-		b := ret[j]
-		return a.Order < b.Order
-	})
-	return ret
+func (repo *Repository) GetNextPasswordId() int {
+	return repo.database.GetNextPasswordId()
 }
 
+func (repo *Repository) IsDirty() bool {
+	return repo.database.IsDirty()
+}
+
+func (repo *Repository) SetClean() {
+	repo.database.SetDirty(false)
+}
+
+// get single password by id
+func (repo *Repository) GetPassword(id int) *model.Password {
+	return repo.database.PasswordMap[id]
+}
+
+// find passwords by search condition
 func (repo *Repository) FindPasswords() []*model.Password {
 	ret := []*model.Password{}
 	sortedCats := repo.GetSortedCategories()
@@ -45,18 +50,7 @@ func (repo *Repository) FindPasswords() []*model.Password {
 	return ret
 }
 
-func (repo *Repository) GetPassword(id int) *model.Password {
-	return repo.database.PasswordMap[id]
-}
-
-func (repo *Repository) GetNextPasswordId() int {
-	return repo.database.GetNextPasswordId()
-}
-
-func (repo *Repository) GetCategories() map[string]*model.Category {
-	return repo.database.CategoryMap
-}
-
+// save password into database
 func (repo *Repository) SavePassword(p *model.Password) {
 	if _, ok := repo.database.PasswordMap[p.ID]; !ok {
 		pwds := repo.database.CategorizedPasswords[p.Category.ID]
@@ -64,22 +58,50 @@ func (repo *Repository) SavePassword(p *model.Password) {
 		repo.database.CategorizedPasswords[p.Category.ID] = pwds
 	}
 	repo.database.PasswordMap[p.ID] = p
+	repo.database.SetDirty(true)
 }
 
+// delete password from database
 func (repo *Repository) DeletePassword(p *model.Password) {
 	delete(repo.database.PasswordMap, p.ID)
+	repo.database.SetDirty(true)
 }
 
-func (repo *Repository) SaveCategory(cat *model.Category) {
-	repo.database.CategoryMap[cat.ID] = cat
-}
-
+// get single category by id
 func (repo *Repository) GetCategory(id string) *model.Category {
 	return repo.database.CategoryMap[id]
 }
 
+// get all categories
+func (repo *Repository) GetCategories() map[string]*model.Category {
+	return repo.database.CategoryMap
+}
+
+// get sorted all categories
+func (repo *Repository) GetSortedCategories() []*model.Category {
+	ret := []*model.Category{}
+	for _, cat := range repo.database.CategoryMap {
+		ret = append(ret, cat)
+	}
+	sort.SliceStable(ret, func(i, j int) bool {
+		a := ret[i]
+		b := ret[j]
+		return a.Order < b.Order
+	})
+	return ret
+}
+
+// save category into database
+func (repo *Repository) SaveCategory(cat *model.Category) {
+	repo.database.CategoryMap[cat.ID] = cat
+	repo.database.SetDirty(true)
+}
+
+// delete category from database
 func (repo *Repository) DeleteCategory(cat *model.Category) {
+	// TODO カテゴリ配下のパスワードを一括で消すorカテゴリ配下にパスワードが存在する場合はエラーにする
 	delete(repo.database.CategoryMap, cat.Name)
+	repo.database.SetDirty(true)
 }
 
 func (repo *Repository) Serialize() [][]*model.Password {

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -73,6 +73,9 @@ func (service *Service) UpdatePassword(c *gin.Context) {
 		// TODO return error response (fix in another task)
 		panic("failed to validate update request")
 	}
+
+	// TODO 変更が一切ないデータが来た場合はcommitしたくないので変更が存在する場合のみSaveする
+
 	repo.SavePassword(pwd)
 	c.PureJSON(http.StatusOK, pwd)
 }
@@ -122,7 +125,12 @@ func (service *Service) CreatePassword(c *gin.Context) {
 }
 
 func (service *Service) Publish(c *gin.Context) {
+	if !service.repo.IsDirty() {
+		c.PureJSON(http.StatusAccepted, map[string]bool{"success": false})
+		return
+	}
 	pwds := service.repo.Serialize()
 	context.Save(pwds)
+	service.repo.SetClean()
 	c.PureJSON(http.StatusOK, map[string]bool{"success": true})
 }


### PR DESCRIPTION
dirtyフラグを導入してdirty時のみpublishするように修正しました。
ただし既存DB値とまったく同じ値を使ってupdateした場合は現状publishされてしまう。

最終的に画面から操作するようになった段階でバリデーションが入ると思われるのでおそらく問題は起こらないが
別タスクでデータ変更有無をチェックして変更があった場合のみdirtyフラグをONにするように修正する。