### PR TITLE
#48: 自動テストのコード整理

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -6,9 +6,6 @@ jobs:
   run-test:
     runs-on: ubuntu-20.04
     steps:
-      - name: install lcov
-        run: sudo apt-get update && sudo apt-get install -y lcov
-
       - name: install go
         uses: actions/setup-go@v3
         with:
@@ -18,31 +15,21 @@ jobs:
         uses: actions/checkout@v3
 
       - name: run go test
+        if: github.ref != 'refs/heads/main'
         run: |
-          # install gcov2lcov
-          export GOBIN=$(pwd)/.bin
-          export PATH=$GOBIN:$PATH
-          echo $GOBIN
-          echo $PATH
-          go install github.com/jandelgado/gcov2lcov@v1.0.5
-
           cd src
           go mod tidy
-          go test -v -coverprofile=cover.out ./...
-          gcov2lcov -infile=cover.out -outfile=../cover.lcov
-          cd ..
-          genhtml cover.lcov -o cover_report
+          go test ./...
+
+      - name: run go test with coverage
+        if: github.ref == 'refs/heads/main'
+        run: |
           cd src
-          go tool cover -html=cover.out -o cover.html
+          go mod tidy
+          go test -coverprofile=cover.out ./...
 
       - name: upload coverage to codecov
+        if: github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODE_COV }}
-          flags: backend-go
-
-      - name: upload report
-        uses: actions/upload-artifact@v3
-        with:
-          name: cover_report
-          path: ./cover_report

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,4 +1,4 @@
-name: test
+name: run-test
 on:
   push:
 


### PR DESCRIPTION
- lcov等を使う必要がなくなったので不要なコードを削除
- mainブランチの時のみカバレッジの算出とアップロードを実施
- main以外のブランチでは単にテストだけを実行する